### PR TITLE
Fix comment for stream_info

### DIFF
--- a/packages/markitdown/src/markitdown/_base_converter.py
+++ b/packages/markitdown/src/markitdown/_base_converter.py
@@ -54,7 +54,7 @@ class DocumentConverter:
         """
         Return a quick determination on if the converter should attempt converting the document.
         This is primarily based `stream_info` (typically, `stream_info.mimetype`, `stream_info.extension`).
-        In cases where the data is retrieved via HTTP, the `steam_info.url` might also be referenced to
+        In cases where the data is retrieved via HTTP, the `stream_info.url` might also be referenced to
         make a determination (e.g., special converters for Wikipedia, YouTube etc).
         Finally, it is conceivable that the `stream_info.filename` might be used to in cases
         where the filename is well-known (e.g., `Dockerfile`, `Makefile`, etc)


### PR DESCRIPTION
## Summary
- fix a typo referencing `stream_info.url` in `_base_converter.py`

## Testing
- `pre-commit run --files packages/markitdown/src/markitdown/_base_converter.py` *(fails: pre-commit not installed)*
- `hatch test` *(fails: hatch not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685fb8a0842c832598bf5f80381b2654